### PR TITLE
AMD support change breaks compatibility with IE

### DIFF
--- a/src/ready.js
+++ b/src/ready.js
@@ -31,7 +31,7 @@
     }
   }))
 
-  return hack ?
+  return (ready = hack ?
     function (fn) {
       self != top ?
         loaded ? fn() : fns.push(fn) :
@@ -46,5 +46,5 @@
     } :
     function (fn) {
       loaded ? fn() : fns.push(fn)
-    }
+    })
 })


### PR DESCRIPTION
The `ready` var was never being assigned. This causes breakage when `hack == true`.
