### PR TITLE
Rename variables and add whitespace for clarity

### DIFF
--- a/ready.js
+++ b/ready.js
@@ -2,28 +2,30 @@
   * domready (c) Dustin Diaz 2014 - License MIT
   */
 !function (name, definition) {
+
   if (typeof module != 'undefined') module.exports = definition()
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
   else this[name] = definition()
+
 }('domready', function () {
 
-  var fns = [], fn, f = false
+  var fns = [], listener
     , doc = document
     , domContentLoaded = 'DOMContentLoaded'
-    , onreadystatechange = 'onreadystatechange'
     , loaded = /^loaded|^c/.test(doc.readyState)
 
-  function flush(f) {
+  function flush (fn) {
     loaded = 1
-    while (f = fns.shift()) f()
+    while (fn = fns.shift()) fn()
   }
 
-  doc.addEventListener(domContentLoaded, fn = function () {
-    doc.removeEventListener(domContentLoaded, fn, f)
+  doc.addEventListener(domContentLoaded, listener = function () {
+    doc.removeEventListener(domContentLoaded, listener)
     flush()
-  }, f)
+  })
 
   return function (fn) {
     loaded ? fn() : fns.push(fn)
   }
+
 });

--- a/ready.min.js
+++ b/ready.min.js
@@ -1,4 +1,4 @@
 /*!
   * domready (c) Dustin Diaz 2014 - License MIT
   */
-!function(e,t){typeof module!="undefined"?module.exports=t():typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(){function u(t){o=1;while(t=e.shift())t()}var e=[],t,n=!1,r=document,i="DOMContentLoaded",s="onreadystatechange",o=/^loaded|^c/.test(r.readyState);return r.addEventListener(i,t=function(){r.removeEventListener(i,t,n),u()},n),function(t){o?t():e.push(t)}})
+!function(e,t){typeof module!="undefined"?module.exports=t():typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(){function s(t){i=1;while(t=e.shift())t()}var e=[],t,n=document,r="DOMContentLoaded",i=/^loaded|^c/.test(n.readyState);return n.addEventListener(r,t=function(){n.removeEventListener(r,t),s()}),function(t){i?t():e.push(t)}})

--- a/src/ready.js
+++ b/src/ready.js
@@ -2,28 +2,30 @@
   * domready (c) Dustin Diaz 2014 - License MIT
   */
 !function (name, definition) {
+
   if (typeof module != 'undefined') module.exports = definition()
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
   else this[name] = definition()
+
 }('domready', function () {
 
-  var fns = [], fn, f = false
+  var fns = [], listener
     , doc = document
     , domContentLoaded = 'DOMContentLoaded'
-    , onreadystatechange = 'onreadystatechange'
     , loaded = /^loaded|^c/.test(doc.readyState)
 
-  function flush(f) {
+  function flush (fn) {
     loaded = 1
-    while (f = fns.shift()) f()
+    while (fn = fns.shift()) fn()
   }
 
-  doc.addEventListener(domContentLoaded, fn = function () {
-    doc.removeEventListener(domContentLoaded, fn, f)
+  doc.addEventListener(domContentLoaded, listener = function () {
+    doc.removeEventListener(domContentLoaded, listener)
     flush()
-  }, f)
+  })
 
   return function (fn) {
     loaded ? fn() : fns.push(fn)
   }
+
 });


### PR DESCRIPTION
Removed the outer `onreadystatechange` variable (unused here; it's an event generated by AJAX requests).

Removed the outer `f` variable (used only as shorthand for `false`) because it was unnecessary (as addEventListener and removeEventListener do not require a third argument `useCapture` which is false by default) and confusing (as the flush function masked the `f` with its own `f` parameter).

Renamed the outer `fn` to `listener`, and the flush function parameter `f` to `fn` (because the `fns` variable holds pending callbacks, and so the name `fn` suggests a variable referencing a single callback).

The flush function parameter `fn` is declared as a parameter only to avoid `var fn` in the flush function body, before the while loop. Misleading at first glance, as someone may see the function signature and expect it receives an argument, but I left that alone because it seemed like a deliberate style choice of the author.

Otherwise I think the changes make the code much more readable.
