### PR TITLE
Check "interactive", skip stuff if already loaded

### DIFF
--- a/ready.js
+++ b/ready.js
@@ -12,8 +12,9 @@
   var fns = [], listener
     , doc = document
     , domContentLoaded = 'DOMContentLoaded'
-    , loaded = /^loaded|^c/.test(doc.readyState)
+    , loaded = /^loaded|^i|^c/.test(doc.readyState)
 
+  if (!loaded)
   doc.addEventListener(domContentLoaded, listener = function () {
     doc.removeEventListener(domContentLoaded, listener)
     loaded = 1

--- a/ready.min.js
+++ b/ready.min.js
@@ -1,4 +1,4 @@
 /*!
   * domready (c) Dustin Diaz 2014 - License MIT
   */
-!function(e,t){typeof module!="undefined"?module.exports=t():typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(){var e=[],t,n=document,r="DOMContentLoaded",i=/^loaded|^c/.test(n.readyState);return n.addEventListener(r,t=function(){n.removeEventListener(r,t),i=1;while(t=e.shift())t()}),function(t){i?t():e.push(t)}})
+!function(e,t){typeof module!="undefined"?module.exports=t():typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(){var e=[],t,n=document,r="DOMContentLoaded",i=/^loaded|^i|^c/.test(n.readyState);return i||n.addEventListener(r,t=function(){n.removeEventListener(r,t),i=1;while(t=e.shift())t()}),function(t){i?t():e.push(t)}})

--- a/src/ready.js
+++ b/src/ready.js
@@ -12,8 +12,9 @@
   var fns = [], listener
     , doc = document
     , domContentLoaded = 'DOMContentLoaded'
-    , loaded = /^loaded|^c/.test(doc.readyState)
+    , loaded = /^loaded|^i|^c/.test(doc.readyState)
 
+  if (!loaded)
   doc.addEventListener(domContentLoaded, listener = function () {
     doc.removeEventListener(domContentLoaded, listener)
     loaded = 1


### PR DESCRIPTION
Inlined the flush behaviour, and added `if (!loaded)` to skip the event listener stuff entirely if the DOM is ready when the domready script executes. This minifies nicely.

I also added a test for `^i` in the regex. This matches "interactive"—which is the value of `readyState` when the event "DOMContentLoaded" occurs. Allows the script to skip the event listener stuff if the state is "interactive" since the event will fire immediately anyway (at least in Chrome; but I was worried that the event listener for "DOMContentLoaded" might never be invoked if it was added after the state is already "interactive"). This is when the DOM is ready, although other resources like fonts and images may still be loading. ([reference](https://developer.mozilla.org/en-US/docs/Web/API/document.readyState))

Feel free to reject this one if you preferred the separate flush function :) 
