### PR TITLE
Don't consider interactive mode as Dom loaded

### DIFF
--- a/ready.js
+++ b/ready.js
@@ -12,7 +12,7 @@
   var fns = [], listener
     , doc = document
     , domContentLoaded = 'DOMContentLoaded'
-    , loaded = /^loaded|^i|^c/.test(doc.readyState)
+    , loaded = /^loaded|^c/.test(doc.readyState)
 
   if (!loaded)
   doc.addEventListener(domContentLoaded, listener = function () {


### PR DESCRIPTION
A month ago it was included this change, 
https://github.com/ded/domready/pull/26

where document.readystate "interactive" was considered equivalent as DOMContentLoaded. 

That's not true in case of IE9 and IE10. They switch to 'interactive' state too early.

This is quite known bug in jQuery. Even it is documented in their code and bug reported.
https://github.com/jquery/jquery/blob/2df1aad6a1c9376c2a477eba26ee992113ed1c23/src/core/ready.js#L76

I replicated the bug here : http://jsfiddle.net/corbacho/d9hLh/embedded/result/
Screenshot http://monosnap.com/image/VqBbDIZSMzLEnLgekxwngpkQ0yYSFw
