### PR TITLE
fixed compatibility for NodeJS environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,11 @@ $(document).ready(function () {
   $('body').html('<p>boosh</p>')
 })
 ```
+
+### Using in NodeJS
+
+When writing tests, you might want to modify your test code to check for `nodom` property of the exported module. That way you can suppress tests that are dependent on DOM.
+
+``` js
+require('domready').nodom
+``` 

--- a/ready.js
+++ b/ready.js
@@ -3,11 +3,17 @@
   */
 !function (name, definition) {
 
-  if (typeof module != 'undefined') module.exports = definition()
+  if (typeof exports !== 'undefined' && this.exports !== exports) module.exports = definition(true)
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
   else this[name] = definition()
 
-}('domready', function () {
+}('domready', function (isNode) {
+
+  if (true === isNode) {
+    var ret = function() {};
+    ret.nodom = true;
+    return ret;
+  }
 
   var fns = [], listener
     , doc = document
@@ -25,4 +31,4 @@
     loaded ? fn() : fns.push(fn)
   }
 
-});
+})

--- a/ready.min.js
+++ b/ready.min.js
@@ -1,4 +1,4 @@
 /*!
   * domready (c) Dustin Diaz 2014 - License MIT
   */
-!function(e,t){typeof module!="undefined"?module.exports=t():typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(){var e=[],t,n=document,r="DOMContentLoaded",i=/^loaded|^i|^c/.test(n.readyState);return i||n.addEventListener(r,t=function(){n.removeEventListener(r,t),i=1;while(t=e.shift())t()}),function(t){i?t():e.push(t)}})
+!function(e,t){typeof exports!="undefined"&&this.exports!==exports?module.exports=t(!0):typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(e){if(!0===e){var t=function(){};return t.nodom=!0,t}var n=[],r,i=document,s="DOMContentLoaded",o=/^loaded|^i|^c/.test(i.readyState);return o||i.addEventListener(s,r=function(){i.removeEventListener(s,r),o=1;while(r=n.shift())r()}),function(e){o?e():n.push(e)}})

--- a/src/ready.js
+++ b/src/ready.js
@@ -3,11 +3,17 @@
   */
 !function (name, definition) {
 
-  if (typeof module != 'undefined') module.exports = definition()
+  if (typeof exports !== 'undefined' && this.exports !== exports) module.exports = definition(true)
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
   else this[name] = definition()
 
-}('domready', function () {
+}('domready', function (isNode) {
+
+  if (true === isNode) {
+    var ret = function() {};
+    ret.nodom = true;
+    return ret;
+  }
 
   var fns = [], listener
     , doc = document
@@ -25,4 +31,4 @@
     loaded ? fn() : fns.push(fn)
   }
 
-});
+})


### PR DESCRIPTION
Alright, this fixes #34 and doesn't throw an exception anymore. As the bonus the exported function has `nodom` boolean property so we are able to check in tests without waiting for the callback that never gets called.

Detection of environment came from [this article](http://timetler.com/2012/10/13/environment-detection-in-javascript/).
