### PR TITLE
adding license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "domready",
     "dom"
   ],
+  "license": "MIT",
   "main": "./ready.js",
   "ender": "./src/ender.js",
   "repository": {


### PR DESCRIPTION
We have some automated tools for license checking that our legal team uses. Right now your module is getting flagged as un-licensed since this field is missing.

:smile: 
