### PR TITLE
Added Bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,36 @@
+{
+  "name": "domready",
+  "description": "modern domready",
+  "homepage": "https://github.com/ded/domready",
+  "authors": [
+    "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)"
+  ],
+  "keywords": [
+    "ender",
+    "domready",
+    "dom"
+  ],
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "main": "./ready.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ded/domready.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ded/domready/issues"
+  },
+  "license": "MIT",
+  "ignore": [
+    ".*",
+    "component.json",
+    "package.json",
+    "Makefile",
+    "make",
+    "src",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I've added a `bower.json` package manifest so that the library can be registered and used with Bower. This improves the ease of use of the library with module bundlers like Browserify that can be configured to prefer installed Bower packages over `node_modules`.
